### PR TITLE
Fix units going invalid in "Troggish Troubles"

### DIFF
--- a/New Profiles (Work In Progress)/Alliance/Eastern Kingdoms/Badlands.xml
+++ b/New Profiles (Work In Progress)/Alliance/Eastern Kingdoms/Badlands.xml
@@ -287,14 +287,13 @@
 								orderby loc.DistanceSquared(Me.Location)
 								select unit).FirstOrDefault();
 
-						while (killUnit != null && killUnit.IsAlive)
+						while (killUnit != null && killUnit.IsValid && killUnit.IsAlive)
 						{
 							Me.SetFacing(killUnit.Location);
 							Lua.DoString("if GetPetActionCooldown(2) == 0 then CastPetAction(2) else CastPetAction(1) end", 0);
 							await Coroutine.Sleep(1000);
-							await Coroutine.Yield();
 						}
-						await Coroutine.Yield();
+						await Coroutine.Sleep(100);
 					}
 				]]>
 			</Code>

--- a/New Profiles (Work In Progress)/Horde/Eastern Kingdoms/Badlands.xml
+++ b/New Profiles (Work In Progress)/Horde/Eastern Kingdoms/Badlands.xml
@@ -266,14 +266,13 @@
 								orderby loc.DistanceSquared(Me.Location)
 								select unit).FirstOrDefault();
 
-						while (killUnit != null && killUnit.IsAlive)
+						while (killUnit != null && killUnit.IsValid && killUnit.IsAlive)
 						{
 							Me.SetFacing(killUnit.Location);
 							Lua.DoString("if GetPetActionCooldown(2) == 0 then CastPetAction(2) else CastPetAction(1) end", 0);
 							await Coroutine.Sleep(1000);
-							await Coroutine.Yield();
 						}
-						await Coroutine.Yield();
+						await Coroutine.Sleep(100);
 					}
 				]]>
 			</Code>


### PR DESCRIPTION
Units could go invalid in this quest and the bot would throw exceptions.